### PR TITLE
데모에 필요한 기본 seo 설정을 진행합니다.

### DIFF
--- a/app/_components/link-to-test.tsx
+++ b/app/_components/link-to-test.tsx
@@ -8,5 +8,5 @@ const StyledLink = styled(Link)`
 `
 
 export function LinkToTest() {
-  return <StyledLink href={'/test'}>테스트 페이지로 이동하기</StyledLink>
+  return <StyledLink href={'/wiki/Next.js'}>Next.js 위키로 이동하기</StyledLink>
 }

--- a/app/_components/not-found.tsx
+++ b/app/_components/not-found.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import Link from 'next/link'
+import styled from 'styled-components'
+
+const StyledLink = styled(Link)`
+  color: blue;
+`
+
+export function Notfound() {
+  return (
+    <div>
+      <h2>Not Found</h2>
+      <p>Could not find requested resource</p>
+      <StyledLink href="/">Return Home</StyledLink>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,26 @@
 import { StyledComponentsRegistry } from './_external/styled-components'
 import { GlobalStyle } from './_styles/global-style'
+import { Metadata } from 'next'
 
 interface LayoutProps {
   children: React.ReactNode
 }
+
+export const metadata: Metadata = {
+  title: '홈 - 데브위키',
+  description: '개발정보를 모아놓은 devwiki입니다.',
+  robots: {
+    index: false,
+    follow: false,
+  },
+  authors: [{ name: 'Devwiki team' }],
+  keywords: ['Devwiki'],
+  alternates: {
+    canonical: 'https://dewiki.vercel.app',
+  },
+}
+
+//QUESTION: 위키피디아 형식에서는 어떤 json-ld 구조화형식이 맞을지..? 아니면 안해도 될지
 
 export default function RootLayout({ children }: LayoutProps) {
   return (

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,5 @@
+import { Notfound } from './_components/not-found'
+
+export default function NotFound() {
+  return <Notfound />
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  //TODO: https://nextjs.org/docs/app/api-reference/functions/generate-sitemaps
+  return [
+    {
+      url: 'https://dewiki.vercel.app',
+      lastModified: new Date(),
+    },
+    {
+      url: 'https://dewiki.vercel.app/wiki/Next.js',
+      lastModified: new Date(),
+    },
+    {
+      url: 'https://dewiki.vercel.app/wiki/Typescript',
+      lastModified: new Date(),
+    },
+    {
+      url: 'https://dewiki.vercel.app/wiki/react-query',
+      lastModified: new Date(),
+    },
+  ]
+}

--- a/app/wiki/[topic]/layout.tsx
+++ b/app/wiki/[topic]/layout.tsx
@@ -6,7 +6,6 @@ interface LayoutProps {
 
 type GenerateMetadataProps = {
   params: { topic: string }
-  searchParams: { [key: string]: string | string[] | undefined }
 }
 
 export async function generateMetadata({ params }: GenerateMetadataProps): Promise<Metadata> {

--- a/app/wiki/[topic]/layout.tsx
+++ b/app/wiki/[topic]/layout.tsx
@@ -1,0 +1,35 @@
+import { Metadata, ResolvingMetadata } from 'next'
+
+interface LayoutProps {
+  children: React.ReactNode
+}
+
+type GenerateMetadataProps = {
+  params: { topic: string }
+  searchParams: { [key: string]: string | string[] | undefined }
+}
+
+export async function generateMetadata({ params }: GenerateMetadataProps): Promise<Metadata> {
+  // read route params
+  const topic = params.topic
+
+  return {
+    title: `${topic} - 데브위키`,
+    // api에서 topic에 대한 description도 같이 받아야함.
+    description: `테스트입니다. - ${topic}`,
+    alternates: {
+      canonical: `https://dewiki.vercel.app/wiki/${topic}`,
+    },
+  }
+}
+
+//QUESTION: 위키피디아 형식에서는 어떤 json-ld 구조화형식이 맞을지..? 아니면 안해도 될지
+
+export default function TopicLayout({ children }: LayoutProps) {
+  return (
+    <html>
+      <head></head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/wiki/[topic]/page.tsx
+++ b/app/wiki/[topic]/page.tsx
@@ -1,0 +1,5 @@
+export default function Topic({ params: { topic }, searchParams }) {
+  console.log({ topic, searchParams })
+
+  return <div>{topic}</div>
+}

--- a/app/wiki/[topic]/page.tsx
+++ b/app/wiki/[topic]/page.tsx
@@ -1,4 +1,19 @@
-export default function Topic({ params: { topic }, searchParams }) {
+import { ReadonlyURLSearchParams } from 'next/navigation'
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return [{ topic: 'Next.js' }, { topic: 'Typescript' }, { topic: 'react-query' }]
+}
+
+interface TopicProps {
+  params: {
+    topic: string
+  }
+  searchParams: ReadonlyURLSearchParams
+}
+
+export default function Topic({ params: { topic }, searchParams }: TopicProps) {
   console.log({ topic, searchParams })
 
   return <div>{topic}</div>

--- a/next.config.js
+++ b/next.config.js
@@ -7,4 +7,22 @@ module.exports = {
   compiler: {
     styledComponents: true,
   },
+  async redirects() {
+    return [
+      //www to non www redirect
+      {
+        source: '/:path*',
+        has: [{ type: 'host', value: 'www.dewiki.vercel.app' }],
+        destination: 'https://dewiki.vercel.app/:path*',
+        permanent: true,
+        statusCode: 301,
+      },
+      {
+        source: '/wiki',
+        destination: '/',
+        permanent: true,
+        statusCode: 301,
+      },
+    ]
+  },
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-Agent: *
+Allow: /
+Sitemap: https://dewiki.vercel.app/sitemap.xml


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- 아래 항목들 중, 필요한 항목을 작성해주세요. -->

## 설명

5/18(토)에 진행할 데모에 맞춰 기본 seo를 설정합니다.

metadata 및 본문내용은 아직 제대로 작성되지 않아 후에 api 및 글 작성 후 마무리 할 예정입니다.

<!-- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (이슈, 슬랙 쓰레드 등) -->

## 변경 내역

- wiki/[topic] 이라는 url로 작성된 글을 볼 수 있도록 라우팅 설정  [ ex) wiki/Next.js ]
- soft 404를 위한 `not-found.tsx` page 추가
- generateStaticParams를 이용하여 작성된 글에 대한 static page 생성, 작성되지 않은 페이지에 대해 404 return
- `next.config.js`의 redirects를 이용하여 유효하지 않은 (www, /wiki) route에 대한 redirect 처리 추가
- sitemap 추가
- robots.txt
- 기본 metadata 추가 `(title, description, robots, author, keywords, alternate(canonical))`

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

## 논의할 점

- 추후 generateStaticParams의 route 생성을 위해서 api가 필요함.
- 추후 sitemap역시 위와 동일한 api가 필요함.
- meta도 title, description에 대한 api가 필요해보임.

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 트러블 슈팅
- `not-found.tsx`는 서버 컴포넌트로 고정이라 styled components를 이용하기위해 `_components/not-found.tsx` 의 클라이언트 컴포넌트를 이용하여 구현
- `export const dynamicParams = false` 다음 구문을 파일 최상위에 작성해야 generateStaticParams로 생성하지 않은 route에 대해 404을 반환함.
- redirects의 옵션중 permanent를 사용하면 308, 사용하지 않으면 307이 나오는데 301 상태코드 반환을 위해서는 statusCode라는 설정이 필요함.
- noindex vs disallow: noindex는 크롤링은 하되 검색결과페이지에 나타나게 하지 않는것이고, disallow는 크롤링 조차 하지 않게한다. (noindex는 metadata, disallow는 robots.txt에서 확인가능)
