### PR TITLE
feat/ISSUE-46-MS Clarity 연동

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { StyledComponentsRegistry } from './_external/styled-components'
 import { GlobalStyle } from './_styles/global-style'
 import { Metadata } from 'next'
 import { GoogleAnalytics } from '@next/third-parties/google'
+import Script from 'next/script'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -29,6 +30,15 @@ export default function RootLayout({ children }: LayoutProps) {
     <html>
       <head>
         <GoogleAnalytics gaId="G-MTBJ5VNE9S" />
+        <Script id="clarity-script" strategy="afterInteractive">
+          {`
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "mo3ghx9sv0");
+          `}
+        </Script>
       </head>
       <body>
         <StyledComponentsRegistry>


### PR DESCRIPTION
## 설명
https://github.com/dev-wiki-kr/dev-wiki/issues/46
히트맵 분석이 가능하도록 [MS Clarity](https://clarity.microsoft.com/) 를 미리 연동합니다.

관련자료 : [Medium - How to Integrate Microsoft Clarity with Your Next.js Application on Vercel](https://medium.com/@mefengl/how-to-integrate-microsoft-clarity-with-your-next-js-application-on-vercel-2caee8427d70)


## 변경 내역
Layout.tsx - `import Script from 'next/script'`
head에 코드 추가

## 논의할 점
MS Clarity에서 동일한 Devwiki.co.kr@gmail.com 계정으로 로그인 하면 히트맵을 볼 수 있습니다.

## 스크린샷
![CleanShot 2024-06-07 at 16 23 22](https://github.com/dev-wiki-kr/dev-wiki/assets/62688329/4f7d93dc-0517-41ff-966a-4e2836fb5797)
