### PR TITLE
 api path 변경

### DIFF
--- a/app/_components/_service/auth.ts
+++ b/app/_components/_service/auth.ts
@@ -21,7 +21,7 @@ function isAuthError(userInfoResponse: UserInfoResponse): userInfoResponse is Us
 export async function getUserInfo() {
   try {
     //TODO: 추후에 환경설정 추가후 same-site로 변경예정
-    const res = await fetch(`http://localhost:8080/api/user`, {
+    const res = await fetch(`https://devwiki.co.kr/wiki-api/user`, {
       credentials: 'include',
     })
 
@@ -29,6 +29,24 @@ export async function getUserInfo() {
 
     if (isAuthError(data)) {
       throw new Error('유저 인증에 실패했습니다.')
+    }
+
+    return data
+  } catch (err) {
+    console.log(err)
+    return null
+  }
+}
+
+export async function getUserInfoByUserName(userName: string) {
+  try {
+    //TODO: 추후에 환경설정 추가후 same-site로 변경예정
+    const res = await fetch(`https://devwiki.co.kr/wiki-api/user/${userName}`)
+
+    const data = (await res.json()) as UserInfoResponse
+
+    if (isAuthError(data)) {
+      throw new Error('존재하지 않는 유저입니다.')
     }
 
     return data

--- a/app/_components/auth/login-link.tsx
+++ b/app/_components/auth/login-link.tsx
@@ -9,5 +9,5 @@ const Link = styled.a`
 `
 
 export function LoginLink() {
-  return <Link href="https://devwiki.co.kr/api/oauth">로그인</Link>
+  return <Link href="https://devwiki.co.kr/wiki-api/oauth">로그인</Link>
 }

--- a/app/_service/post/index.ts
+++ b/app/_service/post/index.ts
@@ -24,7 +24,7 @@ function isPostGetError(postResponse: PostResponse): postResponse is PostError {
 export async function getPostByTitle(title: string) {
   try {
     //TODO: env 처리 추가
-    const res = await fetch(`https://devwiki.co.kr/api/post/${title}`, {
+    const res = await fetch(`https://devwiki.co.kr/wiki-api/post/${title}`, {
       next: { revalidate: 86400 },
     })
 
@@ -46,7 +46,7 @@ type AllTitleResponse = { shortTitle: string }[]
 export async function getAllPostTitle() {
   try {
     //TODO: env 처리 추가
-    const res = await fetch(`https://devwiki.co.kr/api/post/titles`, {
+    const res = await fetch(`https://devwiki.co.kr/wiki-api/post/titles`, {
       next: { revalidate: 86400 },
     })
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- 아래 항목들 중, 필요한 항목을 작성해주세요. -->

## 설명
기존에 /api로 사용하던 api url을 /wiki-api로 변경합니다.

nextjs의 api route가 강제로 /api를 사용하기에 /wiki-api라는 다른 url을 팝니다.

<!-- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (이슈, 슬랙 쓰레드 등) -->
