### PR TITLE
post 페이지에서의 og image나오는 형태를 수정합니다.

### DIFF
--- a/app/_shared/toc/toc-side.tsx
+++ b/app/_shared/toc/toc-side.tsx
@@ -116,8 +116,6 @@ export function TocSide({ tableOfContents }: TocSideProps) {
     }
   }, [headingTops])
 
-  console.log({ tableOfContents })
-
   return (
     <TocContainer>
       <TocWrapper>

--- a/app/post/[topic]/components/markdown-code-syntax.tsx
+++ b/app/post/[topic]/components/markdown-code-syntax.tsx
@@ -4,8 +4,6 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { prism } from 'react-syntax-highlighter/dist/esm/styles/prism'
 
 export const CodeBlock = ({ language, value }: { language: string; value: string }) => {
-  console.log(value)
-
   return (
     <SyntaxHighlighter language={language} style={prism}>
       {value}

--- a/app/post/[topic]/layout.tsx
+++ b/app/post/[topic]/layout.tsx
@@ -18,6 +18,21 @@ export async function generateMetadata({ params }: GenerateMetadataProps): Promi
   return {
     title: `${params.topic} - 데브위키`,
     description: firstContent,
+    openGraph: {
+      title: `${params.topic} - 데브위키`,
+      description: firstContent,
+      type: 'website',
+      locale: 'ko_KR',
+      siteName: 'Devwiki',
+      images: [
+        {
+          url: 'https://devwiki.co.kr/images/opengraph-image.jpg',
+          width: 800,
+          height: 600,
+          alt: 'Devwiki',
+        },
+      ],
+    },
     alternates: {
       canonical: `https://devwiki.co.kr/post/${params.topic}`,
     },


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- 아래 항목들 중, 필요한 항목을 작성해주세요. -->

## 설명

현재 메인과, 상세의 og image가 모두 `홈 - 데브위키` 라는 타이틀로 나와 수정했습니다.

<!-- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (이슈, 슬랙 쓰레드 등) -->
