### PR TITLE
feat : modal Hash Router 추가

### DIFF
--- a/app/_shared/modal/useModal.tsx
+++ b/app/_shared/modal/useModal.tsx
@@ -9,7 +9,7 @@ export function useModal() {
   const handleModal = () => {
     setIsOpen((prevState) => !prevState)
     if (!isOpen) {
-      router.push(`${pathname}#modal`, { scroll: false })
+      router.push(`${pathname}#open`, { scroll: false })
     } else {
       router.push(`${pathname}`, { scroll: true })
     }
@@ -17,7 +17,7 @@ export function useModal() {
 
   useEffect(() => {
     const handleHashChange = () => {
-      if (window.location.hash === '#modal') {
+      if (window.location.hash === '#open') {
         setIsOpen(true)
       } else {
         setIsOpen(false)

--- a/app/_shared/modal/useModal.tsx
+++ b/app/_shared/modal/useModal.tsx
@@ -1,9 +1,21 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
 
 export function useModal() {
   const [isOpen, setIsOpen] = useState(false)
+  const router = useRouter()
+  const pathname = usePathname()
+
   const handleModal = () => {
     setIsOpen((prevState) => !prevState)
   }
+
+  useEffect(() => {
+    if (isOpen) {
+      router.push(`${pathname}#modal`, { scroll: false })
+    } else {
+      router.push(`${pathname}`)
+    }
+  }, [isOpen])
   return { isOpen, handleModal }
 }

--- a/app/_shared/modal/useModal.tsx
+++ b/app/_shared/modal/useModal.tsx
@@ -18,12 +18,19 @@ export function useModal() {
   useEffect(() => {
     const handleHashChange = () => {
       if (window.location.hash === '#modal') {
-        setIsOpen(false)
-      } else {
         setIsOpen(true)
+      } else {
+        setIsOpen(false)
       }
     }
+
     handleHashChange()
+
+    window.addEventListener('hashchange', handleHashChange)
+
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange)
+    }
   }, [pathname])
 
   return { isOpen, handleModal }

--- a/app/_shared/modal/useModal.tsx
+++ b/app/_shared/modal/useModal.tsx
@@ -8,14 +8,23 @@ export function useModal() {
 
   const handleModal = () => {
     setIsOpen((prevState) => !prevState)
+    if (!isOpen) {
+      router.push(`${pathname}#modal`, { scroll: false })
+    } else {
+      router.push(`${pathname}`, { scroll: true })
+    }
   }
 
   useEffect(() => {
-    if (isOpen) {
-      router.push(`${pathname}#modal`, { scroll: false })
-    } else {
-      router.push(`${pathname}`)
+    const handleHashChange = () => {
+      if (window.location.hash === '#modal') {
+        setIsOpen(false)
+      } else {
+        setIsOpen(true)
+      }
     }
-  }, [isOpen])
+    handleHashChange()
+  }, [pathname])
+
   return { isOpen, handleModal }
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- 아래 항목들 중, 필요한 항목을 작성해주세요. -->

## 설명
modal이 나타날 때 hash Route를 추가하였습니다.
pc와 mobile 환경에서 뒤로가기를 누를 시 모달이 닫히도록 하였습니다.

<!-- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (이슈, 슬랙 쓰레드 등) -->

## 변경 내역
공용 모달 컴포넌트의 handleModal 로직에 모달의 상태에 따라 hash route가 추가되도록 하였습니다.
현재 주소에 따라 모달의 상태가 변경되도록 로직을 추가하였습니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

## 논의할 점
mobile 환경에서 뒤로가기를 통해 모달이 닫혀도 검색 input에 focus 되어있는 현상이 존재합니다.
<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

https://github.com/user-attachments/assets/9c99352a-01d6-4d34-8550-5bca3d0650bd


<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
