### PR TITLE
fix: 가상키보드 열릴 시 bottom sheet가 밀리는 버그 해결

### DIFF
--- a/app/_components/search/main-search/main-search.tsx
+++ b/app/_components/search/main-search/main-search.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { css, styled } from 'styled-components'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useModal } from '../../../_shared/modal/useModal'
 import { media } from '../../../_styles/media'
 import { useSearchContainerPosition } from '../context'
@@ -85,6 +85,12 @@ export function MainSearch() {
   const handleChangeKeyword = (keyword: string) => {
     setKeyword(keyword)
   }
+
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.blur()
+    }
+  }, [isOpen])
 
   return (
     <Container>

--- a/app/_shared/bottom-sheet/bottom-sheet-content.tsx
+++ b/app/_shared/bottom-sheet/bottom-sheet-content.tsx
@@ -26,7 +26,9 @@ const Content = styled.div`
 
   background-color: ${({ theme }) => theme.colors.neutral[0]};
 
-  height: 80vh;
+  max-height: 80dvh;
+  min-height: 5dvh;
+  height: 100%;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   transition: transform cubic-bezier(0.32, 0.72, 0, 1);

--- a/app/_shared/bottom-sheet/bottom-sheet-content.tsx
+++ b/app/_shared/bottom-sheet/bottom-sheet-content.tsx
@@ -71,7 +71,7 @@ export const BottomSheetContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivEl
       },
     )
 
-    ref = useMergeRefs([context.refs.setFloating, ref])
+    const bottomSheetRef = useMergeRefs([context.refs.setFloating, ref])
 
     const { isKeyboardOpen, viewportHeight, keyboardHeight } = useKeyboardAwareView()
 
@@ -84,13 +84,12 @@ export const BottomSheetContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivEl
       return null
     }
 
-    console.log(isKeyboardOpen, viewportHeight)
     return (
       <FloatingPortal>
         <Dimmed style={dimmerStyles} lockScroll />
         <FloatingFocusManager context={floatingContext} initialFocus={-1}>
           <Content
-            ref={ref}
+            ref={bottomSheetRef}
             style={{ ...contentStyles, ...bottomSheetStyle }}
             aria-labelledby={context.labelId}
             aria-describedby={context.descriptionId}

--- a/app/_shared/bottom-sheet/bottom-sheet-content.tsx
+++ b/app/_shared/bottom-sheet/bottom-sheet-content.tsx
@@ -5,12 +5,13 @@ import {
   useMergeRefs,
   useTransitionStyles,
 } from '@floating-ui/react'
-import { HTMLProps, forwardRef } from 'react'
+import { CSSProperties, HTMLProps, forwardRef } from 'react'
 import { useBottomSheetContext } from './context'
 import styled from 'styled-components'
+import { useKeyboardAwareView } from '../../hooks/use-keyboard-aware-view'
 
 const Dimmed = styled(FloatingOverlay)`
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgba(0, 0, 0, 0.4);
   display: grid;
   justify-items: center;
   z-index: 50;
@@ -25,13 +26,13 @@ const Content = styled.div`
   z-index: 50;
 
   background-color: ${({ theme }) => theme.colors.neutral[0]};
-
+  height: 80vh;
   max-height: 80dvh;
   min-height: 5dvh;
-  height: 100%;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   transition: transform cubic-bezier(0.32, 0.72, 0, 1);
+  overscroll-behavior: none;
 `
 
 export const BottomSheetContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement>>(
@@ -72,17 +73,25 @@ export const BottomSheetContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivEl
 
     ref = useMergeRefs([context.refs.setFloating, ref])
 
+    const { isKeyboardOpen, viewportHeight, keyboardHeight } = useKeyboardAwareView()
+
+    const bottomSheetStyle: CSSProperties = {
+      height: isKeyboardOpen ? `${viewportHeight * 0.8}px` : '80vh',
+      bottom: isKeyboardOpen ? `${keyboardHeight}px` : '0',
+    }
+
     if (!isDimmerMounted || !isContentMounted) {
       return null
     }
 
+    console.log(isKeyboardOpen, viewportHeight)
     return (
       <FloatingPortal>
         <Dimmed style={dimmerStyles} lockScroll />
-        <FloatingFocusManager context={floatingContext}>
+        <FloatingFocusManager context={floatingContext} initialFocus={-1}>
           <Content
             ref={ref}
-            style={contentStyles}
+            style={{ ...contentStyles, ...bottomSheetStyle }}
             aria-labelledby={context.labelId}
             aria-describedby={context.descriptionId}
             {...context.getFloatingProps(props)}

--- a/app/_shared/bottom-sheet/bottom-sheet-content.tsx
+++ b/app/_shared/bottom-sheet/bottom-sheet-content.tsx
@@ -3,55 +3,21 @@ import {
   FloatingOverlay,
   FloatingFocusManager,
   useMergeRefs,
+  useTransitionStyles,
 } from '@floating-ui/react'
-import { HTMLProps, forwardRef, useEffect, useRef, useState } from 'react'
+import { HTMLProps, forwardRef } from 'react'
 import { useBottomSheetContext } from './context'
-import { styled, keyframes } from 'styled-components'
+import styled from 'styled-components'
 
-const enter = keyframes`
-  0% {
-  opacity: 1;
-  }
-`
-
-const exit = keyframes`
-  to {
-    opacity: 0;
-  }
-`
-
-const slideIn = keyframes`
-  from {
-    transform: translate3d(0, 100%, 0);
-  }
-  to {
-    transform: translate3d(0, 0, 0);
-  }
-`
-
-const slideOut = keyframes`
-  from {
-    transform: translate3d(0, 0, 0);
-  }
-  to {
-    transform: translate3d(0, 120%, 0);
-  }
-`
-
-const Dimmed = styled(FloatingOverlay).withConfig({
-  shouldForwardProp: (prop) => !['isOpen'].includes(prop),
-})<{ isOpen: boolean }>`
-  background-color: rgba(0, 0, 0, 0.8);
+const Dimmed = styled(FloatingOverlay)`
+  background-color: rgba(0, 0, 0, 0.3);
   display: grid;
   justify-items: center;
   z-index: 50;
-
-  animation: ${({ isOpen }) => (isOpen ? enter : exit)} 0.15s forwards;
+  transition: opacity cubic-bezier(0.32, 0.72, 0, 1);
 `
 
-const Content = styled.div.withConfig({
-  shouldForwardProp: (prop) => !['isOpen'].includes(prop),
-})<{ isOpen: boolean }>`
+const Content = styled.div`
   position: fixed;
   bottom: 0;
   right: 0;
@@ -61,62 +27,67 @@ const Content = styled.div.withConfig({
   background-color: ${({ theme }) => theme.colors.neutral[0]};
 
   height: 80vh;
-
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
-
-  animation: ${({ isOpen }) => (isOpen ? slideIn : slideOut)} 0.5s cubic-bezier(0.32, 0.72, 0, 1)
-    forwards;
+  transition: transform cubic-bezier(0.32, 0.72, 0, 1);
 `
 
 export const BottomSheetContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement>>(
   function BottomSheetContent(props, ref) {
     const { context: floatingContext, ...context } = useBottomSheetContext()
-    const contentRef = useRef<HTMLDivElement>(null)
-    const dimmerRef = useRef<HTMLDivElement>(null)
-    const [isMounted, setMounted] = useState(false)
 
-    ref = useMergeRefs([context.refs.setFloating, ref, contentRef]) // ref 병합
+    const { isMounted: isDimmerMounted, styles: dimmerStyles } = useTransitionStyles(
+      floatingContext,
+      {
+        duration: 400,
+        initial: {
+          opacity: 0,
+        },
+        open: {
+          opacity: 1,
+        },
+        close: {
+          opacity: 0,
+        },
+      },
+    )
 
-    useEffect(() => {
-      if (floatingContext.open) {
-        setMounted(true)
-      } else if (contentRef.current) {
-        const handleAnimationEnd = () => {
-          setMounted(false)
-        }
+    const { isMounted: isContentMounted, styles: contentStyles } = useTransitionStyles(
+      floatingContext,
+      {
+        duration: 500,
+        initial: {
+          transform: 'translate3d(0, 100%, 0)',
+        },
+        open: {
+          transform: 'translate3d(0, 0, 0)',
+        },
+        close: {
+          transform: 'translate3d(0, 100%, 0)',
+        },
+      },
+    )
 
-        const contentElement = contentRef.current
+    ref = useMergeRefs([context.refs.setFloating, ref])
 
-        contentElement?.addEventListener('animationend', handleAnimationEnd)
-
-        return () => {
-          if (handleAnimationEnd && contentElement) {
-            contentElement.removeEventListener('animationend', handleAnimationEnd)
-          }
-        }
-      }
-    }, [floatingContext.open])
-
-    if (!isMounted) {
+    if (!isDimmerMounted || !isContentMounted) {
       return null
     }
 
     return (
       <FloatingPortal>
-        <Dimmed ref={dimmerRef} isOpen={floatingContext.open} lockScroll>
-          <FloatingFocusManager context={floatingContext}>
-            <Content
-              ref={ref}
-              aria-labelledby={context.labelId}
-              aria-describedby={context.descriptionId}
-              isOpen={floatingContext.open}
-              {...context.getFloatingProps(props)}
-            >
-              {props.children}
-            </Content>
-          </FloatingFocusManager>
-        </Dimmed>
+        <Dimmed style={dimmerStyles} lockScroll />
+        <FloatingFocusManager context={floatingContext}>
+          <Content
+            ref={ref}
+            style={contentStyles}
+            aria-labelledby={context.labelId}
+            aria-describedby={context.descriptionId}
+            {...context.getFloatingProps(props)}
+          >
+            {props.children}
+          </Content>
+        </FloatingFocusManager>
       </FloatingPortal>
     )
   },

--- a/app/_util/platform.ts
+++ b/app/_util/platform.ts
@@ -9,3 +9,7 @@ export function isMobileClient() {
     navigator.userAgent,
   )
 }
+
+export function isIOSClient() {
+  return /iPhone|iPad|iPod/i.test(navigator.userAgent)
+}

--- a/app/hooks/use-keyboard-aware-view.ts
+++ b/app/hooks/use-keyboard-aware-view.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+
+interface KeyboardAwareViewInfo {
+  isKeyboardOpen: boolean
+  keyboardHeight: number
+  viewportHeight: number
+}
+
+// FIXME: 더 다양한 기기에 대응할 수 있어야함
+const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent)
+
+export function useKeyboardAwareView(): KeyboardAwareViewInfo {
+  const [keyboardInfo, setKeyboardInfo] = useState<KeyboardAwareViewInfo>({
+    isKeyboardOpen: false,
+    keyboardHeight: 0,
+    viewportHeight: window.innerHeight,
+  })
+
+  useEffect(() => {
+    if (!isMobile || !window.visualViewport) {
+      return
+    }
+
+    const INITIAL_VIEWPORT_HEIGHT = window.innerHeight
+
+    function handleResize() {
+      const currentViewportHeight = window.visualViewport!.height
+      const keyboardHeight = Math.max(0, INITIAL_VIEWPORT_HEIGHT - currentViewportHeight)
+
+      setKeyboardInfo({
+        isKeyboardOpen: keyboardHeight > 0,
+        keyboardHeight,
+        viewportHeight: currentViewportHeight,
+      })
+    }
+
+    function handleScroll() {
+      if (keyboardInfo.isKeyboardOpen) {
+        if (document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur()
+        }
+
+        setKeyboardInfo((prevState) => ({
+          ...prevState,
+          isKeyboardOpen: false,
+          keyboardHeight: 0,
+          viewportHeight: window.innerHeight,
+        }))
+      }
+    }
+
+    window.visualViewport.addEventListener('resize', handleResize)
+
+    if (isIOS) {
+      window.addEventListener('scroll', handleScroll)
+    } else {
+      window.visualViewport.addEventListener('scroll', handleScroll)
+    }
+
+    return () => {
+      window.visualViewport!.removeEventListener('resize', handleResize)
+      if (isIOS) {
+        window.removeEventListener('scroll', handleScroll)
+      } else {
+        window.visualViewport!.removeEventListener('scroll', handleScroll)
+      }
+    }
+  }, [keyboardInfo.isKeyboardOpen])
+
+  return keyboardInfo
+}

--- a/app/hooks/use-keyboard-aware-view.ts
+++ b/app/hooks/use-keyboard-aware-view.ts
@@ -1,14 +1,11 @@
 import { useEffect, useState } from 'react'
+import { isIOSClient, isMobileClient } from '../_util/platform'
 
 interface KeyboardAwareViewInfo {
   isKeyboardOpen: boolean
   keyboardHeight: number
   viewportHeight: number
 }
-
-// FIXME: 더 다양한 기기에 대응할 수 있어야함
-const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent)
 
 export function useKeyboardAwareView(): KeyboardAwareViewInfo {
   const [keyboardInfo, setKeyboardInfo] = useState<KeyboardAwareViewInfo>({
@@ -18,7 +15,7 @@ export function useKeyboardAwareView(): KeyboardAwareViewInfo {
   })
 
   useEffect(() => {
-    if (!isMobile || !window.visualViewport) {
+    if (!isMobileClient() || !window.visualViewport) {
       return
     }
 
@@ -52,7 +49,7 @@ export function useKeyboardAwareView(): KeyboardAwareViewInfo {
 
     window.visualViewport.addEventListener('resize', handleResize)
 
-    if (isIOS) {
+    if (isIOSClient()) {
       window.addEventListener('scroll', handleScroll)
     } else {
       window.visualViewport.addEventListener('scroll', handleScroll)
@@ -60,7 +57,7 @@ export function useKeyboardAwareView(): KeyboardAwareViewInfo {
 
     return () => {
       window.visualViewport!.removeEventListener('resize', handleResize)
-      if (isIOS) {
+      if (isIOSClient()) {
         window.removeEventListener('scroll', handleScroll)
       } else {
         window.visualViewport!.removeEventListener('scroll', handleScroll)


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- 아래 항목들 중, 필요한 항목을 작성해주세요. -->

## 설명

close #85
가상키보드 열릴 시 bottom fixed된 요소가 밀리는 문제를 해결합니다.

관련 이슈 https://github.com/dev-wiki-kr/dev-wiki/issues/85#issuecomment-2266677207
ios 키보드가 열렸을 때 viewport가 아닌 document 영역을 키보드 공간만큼 밀어버려서 발생하는 문제인 것 같습니다
(+ aos chrome에서도 같은 문제인 것 같습니다)


<!-- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (이슈, 슬랙 쓰레드 등) -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

Visual Viewport API와 scroll 이벤트를 이용해서 해결하고자 합니다.

1. 바텀시트의 컨텐츠 height를 Visual Viewport의 높이를 기준으로 계산(`viewportHeight * 0.8`)하고
2. bottom 값을 키보드 높이(초기 `window.innerHeight - Visual Viewport Height`)로 설정했습니당
이렇게 해서 키보드가 열렷을 때도 제 위치를 유지하게 했습니다. 

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

해결하면서 또다른 문제가 있었습니다

#### 1. **바텀시트안의 input의 focus로 인해 스크롤이 이동되는 점**
> 키보드 O시 - window.scrollY: 130px // 이부분

지금은 바텀시트가 열리지마자 focus가 가능한 요소(input)로 자동 포커싱되도록 설정되어 있습니다.
그래서 키보드가 열렸을 때 **포커싱 인한 스크롤 이동이 발생**해, 바텀시트가 Visual Viewport 영역보다 더 벗어나고 있었습니다

✅ 바텀시트가 열릴 때 input에 바로 포커스가 가지않도록 해서 해결 (next.js 공식홈 방식 참고)

<br />

#### 2. **키보드가 열린 후에 스크롤 시 설정한 바텀시트 높이보다 오버 스크롤이 되는 문제**

https://github.com/user-attachments/assets/546e762d-f317-4754-ad2d-1105b975728e

지금 방식은 layout viewport 영역의 높이를 바꾸는게 아닌 바텀시트의 높이와 위치를 설정한 것이기 때문에 layout viewport + 가상영역까지 스크롤이 가능합니다
    
  1) 전체화면 높이 수정: innerHeight를 Visual Viewport Height로 바꾼다
 
✅ 2) 스크롤 시 키보드를 닫는다 —> 제일 간단하게 구현가능해서 일단 이렇게 구현했습니당..!

위 문제를 이렇게 해결했는데 더 좋은 방법이 있을까요 ? 🫠


## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->

#### IOS - Safari

https://github.com/user-attachments/assets/8c6b8fd3-7157-4ba5-bcb1-49f8a4761054

#### Android - Chrome

https://github.com/user-attachments/assets/b5d5a100-6c6f-4190-9727-31ac3431c8c4

