### PR TITLE
최신 글에 대한 height 제거

### DIFF
--- a/app/_components/main/latest-article.tsx
+++ b/app/_components/main/latest-article.tsx
@@ -27,7 +27,6 @@ const StyledDocumentContainer = styled.div`
 
 const StyledDocumentLink = styled(Link)`
   width: 198px;
-  height: 24px;
   margin-bottom: 10px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- 아래 항목들 중, 필요한 항목을 작성해주세요. -->

## 설명
제목이 긴 글에 대해서 ui가 깨져보이는 문제가 발생하여 최신 글에 붙어있는 height 속성을 제거

<!-- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (이슈, 슬랙 쓰레드 등) -->

## 스크린샷

기존 ui
<img width="439" alt="스크린샷 2024-09-03 오전 3 31 53" src="https://github.com/user-attachments/assets/f8243d96-463f-49ac-bf6c-b16364d6b60f">

수정 ui
<img width="491" alt="스크린샷 2024-09-03 오전 3 32 36" src="https://github.com/user-attachments/assets/122bee88-49aa-4749-8d78-d8d12aba8093">

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
