### PR TITLE
not found 페이지가 나오지 않고 깨지는 문제 수정

### DIFF
--- a/app/post/[topic]/layout.tsx
+++ b/app/post/[topic]/layout.tsx
@@ -13,7 +13,7 @@ export async function generateMetadata({ params }: GenerateMetadataProps): Promi
 
   const post = await getPostByTitle(params.topic)
 
-  const firstContent = parseMarkdown(post?.content || '')[0].content
+  const firstContent = parseMarkdown(post?.content || '')[0]?.content
 
   return {
     title: `${params.topic} - 데브위키`,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- 아래 항목들 중, 필요한 항목을 작성해주세요. -->

## 설명

현재 잘못된 url로 들어가면 not found 페이지가 아니라 client side error가 발생하는 문제를 수정합니다.

## 변경 내역

generateMetaData의 optional을 추가했습니다.