### PR TITLE
title이 url의 name으로 들어가고 있던 문제 수정

### DIFF
--- a/app/post/[topic]/layout.tsx
+++ b/app/post/[topic]/layout.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from 'react'
 import { Container } from './components/container'
 import { Metadata } from 'next'
 import { getPostByTitle } from '../../_service/post'
-import { parseMarkdown } from '../../_engine/parse-accordion'
+import { parseMarkdown, parseMarkdownTitle } from '../../_engine/parse-accordion'
 
 type GenerateMetadataProps = {
   params: { topic: string }
@@ -13,10 +13,12 @@ export async function generateMetadata({ params }: GenerateMetadataProps): Promi
 
   const post = await getPostByTitle(params.topic)
 
+  const title = parseMarkdownTitle(post?.content || '').replace('# ', '')
+
   const firstContent = parseMarkdown(post?.content || '')[0]?.content
 
   return {
-    title: `${params.topic} - 데브위키`,
+    title: `${title} - 데브위키`,
     description: firstContent,
     openGraph: {
       title: `${params.topic} - 데브위키`,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- 아래 항목들 중, 필요한 항목을 작성해주세요. -->

## 설명
다음과 같이 실제 제목이 title이 되는것이 아니라 post/[topic] 에 있는 topic이 meta-data의 title로 들어가고 있음

<img width="656" alt="스크린샷 2024-09-05 오전 3 01 52" src="https://github.com/user-attachments/assets/6ba0d3a1-7a8e-4f76-bbaa-2877c637a2a3">
